### PR TITLE
Avoid RT stalls in MRT and optional DDP worker affinity

### DIFF
--- a/core/ocs2_core/include/ocs2_core/thread_support/SetThreadPriority.h
+++ b/core/ocs2_core/include/ocs2_core/thread_support/SetThreadPriority.h
@@ -30,8 +30,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <pthread.h>
+#include <sched.h>
+
 #include <iostream>
 #include <thread>
+#include <vector>
 
 namespace ocs2 {
 
@@ -71,6 +74,34 @@ inline void setThreadPriority(int priority, std::thread& thread) {
  */
 inline void setThisThreadPriority(int priority) {
   setThreadPriority(priority, pthread_self());
+}
+
+/**
+ * Pin a thread to the given CPUs. Empty list is a no-op.
+ */
+inline void setThreadCpuAffinity(pthread_t thread, const std::vector<int>& cpus) {
+  if (cpus.empty()) {
+    return;
+  }
+  cpu_set_t set;
+  CPU_ZERO(&set);
+  bool any = false;
+  for (const int cpu : cpus) {
+    if (cpu >= 0 && cpu < CPU_SETSIZE) {
+      CPU_SET(cpu, &set);
+      any = true;
+    }
+  }
+  if (!any) {
+    return;
+  }
+  if (pthread_setaffinity_np(thread, sizeof(set), &set) != 0) {
+    std::cerr << "WARNING: Failed to set thread CPU affinity\n";
+  }
+}
+
+inline void setThreadCpuAffinity(std::thread& thread, const std::vector<int>& cpus) {
+  setThreadCpuAffinity(thread.native_handle(), cpus);
 }
 
 }  // namespace ocs2

--- a/core/ocs2_core/include/ocs2_core/thread_support/ThreadPool.h
+++ b/core/ocs2_core/include/ocs2_core/thread_support/ThreadPool.h
@@ -44,6 +44,13 @@ namespace ocs2 {
 class ThreadPool {
  public:
   /**
+   * CPU affinity applied to workers created by the next ThreadPool constructor.
+   * Used to keep DDP helpers off the RT control core without changing DDP_Settings.
+   * Empty list (default) leaves affinity unchanged.
+   */
+  static void setLaunchWorkerCpuAffinity(std::vector<int> cpus);
+
+  /**
    * Constructor
    *
    * @param [in] nThreads: Number of threads to launch in the pool

--- a/core/ocs2_core/src/thread_support/ThreadPool.cpp
+++ b/core/ocs2_core/src/thread_support/ThreadPool.cpp
@@ -30,12 +30,31 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ocs2_core/thread_support/SetThreadPriority.h>
 #include <ocs2_core/thread_support/ThreadPool.h>
 
+#include <mutex>
+#include <vector>
+
 namespace ocs2 {
+    namespace {
+        std::mutex launchAffinityMutex;
+        std::vector<int> launchWorkerCpuAffinity;
+    }  // namespace
+
+    void ThreadPool::setLaunchWorkerCpuAffinity(std::vector<int> cpus) {
+        std::lock_guard<std::mutex> lock(launchAffinityMutex);
+        launchWorkerCpuAffinity = std::move(cpus);
+    }
+
     ThreadPool::ThreadPool(size_t nThreads, int priority) {
+        std::vector<int> cpus;
+        {
+            std::lock_guard<std::mutex> lock(launchAffinityMutex);
+            cpus = launchWorkerCpuAffinity;
+        }
         workerThreads_.reserve(nThreads);
         for (size_t i = 0; i < nThreads; i++) {
             workerThreads_.emplace_back(&ThreadPool::worker, this, i);
             setThreadPriority(priority, workerThreads_.back());
+            setThreadCpuAffinity(workerThreads_.back(), cpus);
         }
     }
 

--- a/mpc/ocs2_mpc/include/ocs2_mpc/MPC_MRT_Interface.h
+++ b/mpc/ocs2_mpc/include/ocs2_mpc/MPC_MRT_Interface.h
@@ -31,6 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <condition_variable>
 #include <csignal>
+#include <memory>
 
 #include <ocs2_core/misc/Benchmark.h>
 #include <ocs2_core/model_data/Multiplier.h>
@@ -68,6 +69,12 @@ namespace ocs2 {
          * control law that was up-to-date at the last updatePolicy() call.
          */
         void advanceMpc();
+
+        /**
+         * Downsampled state trajectory prepared on the MPC thread during copyToBuffer().
+         * RT may atomic-load this pointer without copying the trajectory vectors.
+         */
+        std::shared_ptr<const vector_array_t> getVisualizationStateTrajectory() const;
 
         /**
          * @brief Retrieves the gain matrix from solver capable of optimizing over LinearController type.
@@ -125,5 +132,6 @@ namespace ocs2 {
         // MPC inputs
         SystemObservation currentObservation_;
         std::mutex observationMutex_;
+        mutable std::shared_ptr<const vector_array_t> visualizationStateTrajectory_;
     };
 } // namespace ocs2

--- a/mpc/ocs2_mpc/src/MPC_MRT_Interface.cpp
+++ b/mpc/ocs2_mpc/src/MPC_MRT_Interface.cpp
@@ -29,10 +29,35 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "ocs2_mpc/MPC_MRT_Interface.h"
 
+#include <algorithm>
+#include <atomic>
+#include <memory>
+
 #include <ocs2_core/control/FeedforwardController.h>
 #include <ocs2_core/control/LinearController.h>
 
 namespace ocs2 {
+    namespace {
+        constexpr size_t kMaxVisualizationTrajectoryPoints = 32;
+
+        std::shared_ptr<const vector_array_t> downsampleStateTrajectory(const vector_array_t& in) {
+            auto out = std::make_shared<vector_array_t>();
+            if (in.empty()) {
+                return out;
+            }
+            const size_t n = in.size();
+            const size_t step = std::max<size_t>(1, (n + kMaxVisualizationTrajectoryPoints - 1) / kMaxVisualizationTrajectoryPoints);
+            out->reserve((n + step - 1) / step + 1);
+            for (size_t i = 0; i < n; i += step) {
+                out->push_back(in[i]);
+            }
+            if ((n - 1) % step != 0) {
+                out->push_back(in.back());
+            }
+            return out;
+        }
+    }  // namespace
+
     MPC_MRT_Interface::MPC_MRT_Interface(MPC_BASE &mpc) : mpc_(mpc) {
         mpcTimer_.reset();
     }
@@ -46,8 +71,12 @@ namespace ocs2 {
 
 
     void MPC_MRT_Interface::setCurrentObservation(const SystemObservation &currentObservation) {
-        std::lock_guard<std::mutex> lock(observationMutex_);
+        // RT must not block behind advanceMpc()'s copy (priority inversion on a shared core).
+        if (!observationMutex_.try_lock()) {
+            return;
+        }
         currentObservation_ = currentObservation;
+        observationMutex_.unlock();
     }
 
 
@@ -118,7 +147,16 @@ namespace ocs2 {
         auto performanceIndicesPtr = std::make_unique<PerformanceIndex>();
         *performanceIndicesPtr = mpc_.getSolverPtr()->getPerformanceIndeces();
 
+        std::atomic_store_explicit(&visualizationStateTrajectory_,
+                                   downsampleStateTrajectory(primalSolutionPtr->stateTrajectory_),
+                                   std::memory_order_release);
+
         this->moveToBuffer(std::move(commandPtr), std::move(primalSolutionPtr), std::move(performanceIndicesPtr));
+    }
+
+
+    std::shared_ptr<const vector_array_t> MPC_MRT_Interface::getVisualizationStateTrajectory() const {
+        return std::atomic_load_explicit(&visualizationStateTrajectory_, std::memory_order_acquire);
     }
 
 


### PR DESCRIPTION
## Summary
- `setCurrentObservation` uses `try_lock` so the 500 Hz thread cannot block behind `advanceMpc`.
- The MPC thread prepares a downsampled state-trajectory `shared_ptr` for visualization instead of deep-copying on the control thread.
- `ThreadPool` can inherit a launch CPU affinity so DDP helpers stay off the isolated control core (no-op when unset).

## Test plan
- [ ] Build `ocs2_core` + `ocs2_mpc` on Jazzy.
- [ ] On a machine **without** `cpu_affinity`, MPC/DDP still run (affinity left unchanged).
- [ ] With isolcpus + `cpu_affinity`, confirm DDP workers are not on the 500 Hz core.
- [ ] Drag RViz markers and confirm visualization still shows an EE trajectory (downsampled).


Made with [Cursor](https://cursor.com)