### PR TITLE
fix(ci): prefer Azure apt mirrors in ros containers

### DIFF
--- a/.github/scripts/configure_ci_apt.sh
+++ b/.github/scripts/configure_ci_apt.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Rewrite Canonical Ubuntu apt URIs to Azure-first mirror lists.
+# ros:* containers do not inherit GitHub-hosted runner Azure mirrors, so
+# archive.ubuntu.com / ports.ubuntu.com can stall for tens of minutes.
+set -eo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+cat >/etc/apt/apt.conf.d/99-ci-acquire <<'EOF'
+Acquire::Retries "1";
+Acquire::http::Timeout "15";
+Acquire::https::Timeout "15";
+Acquire::Languages "none";
+Acquire::IndexTargets::deb::DEP-11::DefaultEnabled "false";
+EOF
+
+mirrors_file=/etc/apt/ci-ubuntu-mirrors.txt
+if [[ "$(dpkg --print-architecture)" == "arm64" ]]; then
+  printf '%s\n' \
+    $'http://azure.ports.ubuntu.com/ubuntu-ports/\tpriority:1' \
+    $'http://ports.ubuntu.com/ubuntu-ports/\tpriority:2' \
+    > "$mirrors_file"
+else
+  printf '%s\n' \
+    $'http://azure.archive.ubuntu.com/ubuntu/\tpriority:1' \
+    $'http://archive.ubuntu.com/ubuntu/\tpriority:2' \
+    $'http://security.ubuntu.com/ubuntu/\tpriority:3' \
+    > "$mirrors_file"
+fi
+
+rewrite_ubuntu_mirrors() {
+  local f="$1"
+  [[ -f "$f" ]] || return 0
+  sed -E -i \
+    -e 's#https?://(archive|security)\.ubuntu\.com/ubuntu/?#mirror+file:/etc/apt/ci-ubuntu-mirrors.txt#g' \
+    -e 's#https?://ports\.ubuntu\.com/ubuntu-ports/?#mirror+file:/etc/apt/ci-ubuntu-mirrors.txt#g' \
+    "$f"
+}
+rewrite_ubuntu_mirrors /etc/apt/sources.list
+shopt -s nullglob
+for f in /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+  rewrite_ubuntu_mirrors "$f"
+done
+
+echo "Ubuntu apt mirrors ($(dpkg --print-architecture)):"
+cat "$mirrors_file"
+grep -RInE 'URIs:|^deb ' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null || true

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -38,6 +38,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_type == 'tag' && github.ref_name || (github.event_name == 'pull_request' && 'pre-release' || github.ref) }}-${{ github.event.inputs.release_tag || '' }}
@@ -180,9 +181,12 @@ jobs:
           done < /tmp/release_meta.txt
 
       - name: Install system tools
+        timeout-minutes: 10
         shell: bash
         run: |
           set -eo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          bash .github/scripts/configure_ci_apt.sh
           apt-get update
           apt-get install -y \
             pybind11-dev \
@@ -216,9 +220,11 @@ jobs:
             ccache-${{ matrix.ros_distro }}-${{ matrix.arch }}-
 
       - name: Install package dependencies via rosdep
+        timeout-minutes: 15
         shell: bash
         run: |
           set -eo pipefail
+          export DEBIAN_FRONTEND=noninteractive
           source "/opt/ros/${{ matrix.ros_distro }}/setup.bash"
           # Limit paths to core + basic examples; advance examples / plane_segmentation
           # submodules pull extra keys and can fail unrelated packages.

--- a/.github/workflows/verify-deb.yml
+++ b/.github/workflows/verify-deb.yml
@@ -112,9 +112,12 @@ jobs:
       # Match build-deb: Jazzy on Noble, Lyrical on Resolute. Noble apt has no
       # ros-lyrical packages (Tier 1 Lyrical is Ubuntu 26.04 only).
       - name: Install verify tools
+        timeout-minutes: 8
         shell: bash
         run: |
           set -eo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          bash .github/scripts/configure_ci_apt.sh
           apt-get update
           apt-get install -y curl ca-certificates cmake build-essential git
           if ! command -v gh >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Rewrite Canonical Ubuntu apt sources inside `ros:*` containers to Azure-first mirror lists with short Acquire timeouts, so amd64 jobs stop stalling on `archive.ubuntu.com`.
- Grant `actions: write` so `actions/cache` can save ccache.
- Add timeouts on apt/rosdep steps in build and verify workflows.

## Test plan
- [ ] This workflow does **not** run on PR open — trigger **workflow_dispatch** on `fix/cicd-azure` (or merge to `ros2`) to actually build debs.
- [ ] Confirm amd64 `Install system tools` / `rosdep` finish in about a minute, not 10–40 minutes, and no `Connection failed [archive.ubuntu.com]` errors.
- [ ] Confirm `Restore ccache` / post-cache no longer warn `token has no writable scopes`.
- [ ] Confirm jazzy + lyrical, amd64 + arm64 still succeed.


Made with [Cursor](https://cursor.com)